### PR TITLE
remove useless Makefile.prow

### DIFF
--- a/Makefile.prow
+++ b/Makefile.prow
@@ -1,4 +1,0 @@
-# Copyright (c) 2021 Red Hat, Inc.
-# Copyright Contributors to the Open Cluster Management project
-
--include /opt/build-harness/Makefile.prow


### PR DESCRIPTION
Revert https://github.com/open-cluster-management/observatorium/pull/1

Signed-off-by: haoqing0110 <qhao@redhat.com>