### PR TITLE
remove "go mod tidy" from the make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,6 @@ build: observatorium
 
 .PHONY: vendor
 vendor: go.mod go.sum
-	go mod tidy
 	go mod vendor
 
 .PHONY: format


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/13135

due to comments in https://projects.engineering.redhat.com/browse/CLOUDBLD-6006?focusedCommentId=3251841&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-3251841
remove "go mod tidy" in makefile to make ds build can work

Signed-off-by: Marco <llan@redhat.com>